### PR TITLE
v1.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -15,59 +15,14 @@ Add a customizable subtitle to your widgets
 
 This plugin adds a subtitle input field to all your widgets. You can also change the location of the subtitle and even use filters to change the subtitle output.
 
-= Filter: `widget_subtitles_element` =
-Allows you to change the HTML element for the subtitle.  
-Since  1.0  
-
-*	**Default:** `span`
-*	**Parameters:**
-	*	`string`    Default element.
-	*	`string`    Widget ID, widget name + instance number.
-	*	`string`    Sidebar ID where this widget is located. (since 1.1)
-	*	`array`     All widget data. (since 1.1)
-	*	`WP_Widget` The widget type class. (since 1.1.3)
-*	**Return:** `string` A valid HTML element.
-
-= Filter: `widget_subtitles_classes` =
-Allow filter for subtitle classes to overwrite, remove or add classes.  
-Since  1.0  
-
-*	**Default:** `array( 'widget-subtitle', 'widgetsubtitle', 'subtitle-{LOCATION}' );` *Where {LOCATION} stands for your selected location*.
-*	**Parameters:**
-	*	`string`    Default element.
-	*	`string`    Widget ID, widget name + instance number.
-	*	`string`    Sidebar ID where this widget is located. (since 1.1)
-	*	`array`     All widget data. (since 1.1)
-	*	`WP_Widget` The widget type class. (since 1.1.3)
-*	**Return:** `array` An array of CSS classes.
-
-= Filter: `widget_subtitles_default_location` =
-Sets the default location for subtitles.  
-Since  1.1.2  
-
-*	**Default:** `after-inside`
-*	**Parameters:** `string` The default subtitle location.
-*	**Return:** `string` Options: `after-inside`, `after-outside`, `before-inside`, `before-outside`.
-
-= Filter: `widget_subtitles_edit_location_capability` =
-Change the capability required to modify subtitle locations.  
-Since  1.1.2  
-
-*	**Default:** `edit_theme_options`
-*	**Parameters:** `string` The default capability.
-*	**Return:** `string` The new capability.
-
-= Filter: `widget_subtitles_available_locations` =
-Overwrites the available locations for a widget.  
-NOTE: You can currently only remove locations. New locations are not possible (yet).  
-Since  1.1.3  
-
-*	**Default:** `after-inside`, `after-outside`, `before-inside`, `before-outside`.
-*	**Parameters:**
-	*	`array`      The array of available locations.
-	*	`WP_Widget`  The widget type class.
-	*	`array`      The widget instance.
-*	**Return:** `array` Filtered list of available locations for this widget.
+= Filters =
+*   [`widget_subtitles_element`](https://github.com/JoryHogeveen/widget-subtitles/wiki#filter-widget_subtitles_element)
+*   [`widget_subtitles_classes`](https://github.com/JoryHogeveen/widget-subtitles/wiki#filter-widget_subtitles_classes)
+*   [`widget_subtitles_default_location`](https://github.com/JoryHogeveen/widget-subtitles/wiki#filter-widget_subtitles_default_location)
+*   [`widget_subtitles_edit_location_capability`](https://github.com/JoryHogeveen/widget-subtitles/wiki#filter-widget_subtitles_edit_location_capability)
+*   [`widget_subtitles_available_locations`](https://github.com/JoryHogeveen/widget-subtitles/wiki#filter-widget_subtitles_available_locations)
+*   [`widget_subtitles_add_subtitle`](https://github.com/JoryHogeveen/widget-subtitles/wiki#filter-widget_subtitles_add_subtitle)
+*   [`widget_subtitle`](https://github.com/JoryHogeveen/widget-subtitles/wiki#filter-widget_subtitle)
 
 You can use these filters inside your theme functions.php file or in a plugin.
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: widget, widget subtitle, subtitle, subtitles, sub title, sidebar
 Requires at least: 3.0
 Tested up to: 4.9
 Requires PHP: 5.2.4
-Stable tag: 1.1.4.1
+Stable tag: 1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -41,6 +41,16 @@ Or search for "Widget Subtitles" via your plugins menu.
 2. Frontend subtitle example (after title - inside heading)
 
 == Changelog ==
+
+= 1.2 =
+
+*	**Feature:** New filter: `widget_subtitle` to change the subtitle for a widget. Similar to WP's `widget_title`.
+*	**Feature:** New filter: `widget_subtitles_add_subtitle` to allow custom subtitle location handlers.
+*	**Enhancement:** Extended filter: `widget_subtitles_available_locations` now allows custom locations.
+*	**Enhancement:** Make use of `wp_get_sidebars_widgets()` instead of a global to get the related sidebar ID from a widget instance.
+*	**Documentation:** Created a wiki on GitHub.
+
+Detailed info: [PR on GitHub](https://github.com/JoryHogeveen/widget-subtitles/pull/11)
 
 = 1.1.4.1 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Widget Subtitles ===
 Contributors: keraweb
-Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=YGPLMLU7XQ9E8&lc=NL&item_name=Widget%20Subtitles&item_number=JWPP%2dWS&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHostedGuest
+Donate link: https://www.keraweb.nl/donate.php?for=widget-subtitles
 Tags: widget, widget subtitle, subtitle, subtitles, sub title, sidebar
 Requires at least: 3.0
 Tested up to: 4.9

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -191,7 +191,7 @@ class PluginTest extends WP_UnitTestCase {
 
 		// Run tests
 		foreach ( $tests as $test ) {
-			$this->assertEquals( $test['result'], $ws->widget_update_callback( $test['start'], $test['data'] ) );
+			$this->assertEquals( $test['result'], $ws->filter_widget_update_callback( $test['start'], $test['data'] ) );
 		}
 	}
 }

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -134,16 +134,6 @@ class PluginTest extends WP_UnitTestCase {
 				'start'  => array(),
 				'data'   => array(
 					'subtitle' => 'test',
-					'subtitle_location' => '1', // Not valid.
-				),
-				'result' => array(
-					'subtitle' => 'test',
-				),
-			),
-			array(
-				'start'  => array(),
-				'data'   => array(
-					'subtitle' => 'test',
 					'subtitle_location' => '', // Not valid.
 				),
 				'result' => array(

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -16,13 +16,11 @@ class PluginTest extends WP_UnitTestCase {
 
 	// Check for PHP errors
 	function test_general() {
-		$ws = ws_widget_subtitles();
-		$ws->get_links();
+		ws_widget_subtitles()->get_links();
 	}
 
 	// Check add_subtitle() method.
 	function test_add_subtitle() {
-		$ws = ws_widget_subtitles();
 
 		$tests = array(
 			array(
@@ -118,16 +116,49 @@ class PluginTest extends WP_UnitTestCase {
 				),
 				'location' => 'after-outside', // default
 			),
-		);
 
 		foreach ( $tests as $test ) {
-			$this->assertEquals( $test['result'], $ws->add_subtitle( $test['start'], $test['data'], $test['location'] ) );
+			$this->assertEquals(
+				$test['result'],
+				ws_widget_subtitles()->add_subtitle( $test['start'], $test['data'], $test['location'] )
+			);
 		}
 	}
 
-	// Check widget_update_callback() method
+	// Check get_subtitle_classes() method.
+	function test_get_subtitle_classes() {
+
+		$tests = array(
+			array(
+				'result' => array(
+					'widgetsubtitle',
+					'widget-subtitle',
+					'subtitle-after-outside',
+					'subtitle-after',
+					'subtitle-outside',
+				),
+				'location' => 'after-outside', // default
+			),
+			array(
+				'result' => array(
+					'widgetsubtitle',
+					'widget-subtitle',
+					'subtitle-custom',
+				),
+				'location' => 'custom', // default
+			),
+		);
+
+		foreach ( $tests as $test ) {
+			$this->assertEquals(
+				$test['result'],
+				ws_widget_subtitles()->get_subtitle_classes( $test['location'] )
+			);
+		}
+	}
+
+	// Check filter_widget_update_callback() method
 	function test_widget_update_callback() {
-		$ws = ws_widget_subtitles();
 
 		$tests = array(
 			array(
@@ -191,7 +222,10 @@ class PluginTest extends WP_UnitTestCase {
 
 		// Run tests
 		foreach ( $tests as $test ) {
-			$this->assertEquals( $test['result'], $ws->filter_widget_update_callback( $test['start'], $test['data'] ) );
+			$this->assertEquals(
+				$test['result'],
+				ws_widget_subtitles()->filter_widget_update_callback( $test['start'], $test['data'] )
+			);
 		}
 	}
 }

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -116,6 +116,21 @@ class PluginTest extends WP_UnitTestCase {
 				),
 				'location' => 'after-outside', // default
 			),
+			array(
+				'start'  => array(
+					'after_title' => '</div>',
+					'before_title' => '<div class="title">',
+				),
+				'data'   => '<div>SUBTITLE</div>',
+				'result' => array(
+					'after_title' => '</div>',
+					'before_title' => '<div class="title"><div>SUBTITLE</div> test ',
+				),
+				'location' => 'custom', // default
+			),
+		);
+
+		add_filter( 'widget_subtitles_add_subtitle', array( $this, 'filter_widget_subtitles_add_subtitle' ), 10, 3 );
 
 		foreach ( $tests as $test ) {
 			$this->assertEquals(
@@ -123,6 +138,13 @@ class PluginTest extends WP_UnitTestCase {
 				ws_widget_subtitles()->add_subtitle( $test['start'], $test['data'], $test['location'] )
 			);
 		}
+	}
+
+	function filter_widget_subtitles_add_subtitle( $params, $subtitle, $subtitle_location ) {
+		if ( 'custom' === $subtitle_location ) {
+			$params['before_title'] = $params['before_title'] . $subtitle . ' test ';
+		}
+		return $params;
 	}
 
 	// Check get_subtitle_classes() method.

--- a/widget-subtitles.php
+++ b/widget-subtitles.php
@@ -552,8 +552,12 @@ final class WS_Widget_Subtitles
 		// Add subtitle location classes.
 		$subtitle_classes[] = 'subtitle-' . $location;
 		$location_classes = explode( '-', $location );
-		foreach ( $location_classes as $location_class ) {
-			$subtitle_classes[] = 'subtitle-' . $location_class;
+		// Prevent duplicated classes.
+		if ( 1 < count( $location_classes ) ) {
+			// Add location part classes.
+			foreach ( $location_classes as $location_class ) {
+				$subtitle_classes[] = 'subtitle-' . $location_class;
+			}
 		}
 		return $subtitle_classes;
 	}

--- a/widget-subtitles.php
+++ b/widget-subtitles.php
@@ -3,7 +3,7 @@
  * @author  Jory Hogeveen <info@keraweb.nl>
  * @package Widget_Subtitles
  * @since   0.1.0
- * @version 1.2.0-dev
+ * @version 1.2.0
  * @licence GPL-2.0+
  * @link    https://github.com/JoryHogeveen/widget-subtitles
  *
@@ -11,7 +11,7 @@
  * Plugin Name:       Widget Subtitles
  * Plugin URI:        https://wordpress.org/plugins/widget-subtitles/
  * Description:       Add a customizable subtitle to your widgets
- * Version:           1.2-rc1
+ * Version:           1.2
  * Author:            Jory Hogeveen
  * Author URI:        http://www.keraweb.nl
  * Text Domain:       widget-subtitles
@@ -211,7 +211,7 @@ final class WS_Widget_Subtitles
 	 * Add a subtitle input field into the form.
 	 *
 	 * @since   0.1.0
-	 * @since   0.2.0  Add `action_` prefix.
+	 * @since   1.2.0  Add `action_` prefix.
 	 * @access  public
 	 *
 	 * @param   \WP_Widget  $widget
@@ -297,7 +297,7 @@ final class WS_Widget_Subtitles
 	 * Filter the widget’s settings before saving, return false to cancel saving (keep the old settings if updating).
 	 *
 	 * @since   0.1.0
-	 * @since   0.2.0  Add `filter_` prefix.
+	 * @since   1.2.0  Add `filter_` prefix.
 	 * @access  public
 	 *
 	 * @param   array       $instance
@@ -330,7 +330,7 @@ final class WS_Widget_Subtitles
 	 * @SuppressWarnings(PHPMD.LongVariables)
 	 *
 	 * @since   0.1.0
-	 * @since   0.2.0  Add `filter_` prefix.
+	 * @since   1.2.0  Add `filter_` prefix.
 	 * @access  public
 	 *
 	 * @global  $wp_registered_widgets

--- a/widget-subtitles.php
+++ b/widget-subtitles.php
@@ -237,19 +237,12 @@ final class WS_Widget_Subtitles
 			<input class="widefat" id="<?php echo $widget->get_field_id( 'subtitle' ); ?>" name="<?php echo $widget->get_field_name( 'subtitle' ); ?>" type="text" value="<?php echo esc_attr( strip_tags( $instance['subtitle'] ) ); ?>"/>
 		</p>
 
-		<?php
-		$locations = array();
-
-		if ( $can_edit_location ) {
-			$locations = $this->get_available_subtitle_locations( $widget, $instance );
-		}
-
-		if ( 1 < count( $locations ) ) {
-		?>
+		<?php if ( $can_edit_location ) { ?>
 		<p>
 			<label for="<?php echo $widget->get_field_id( 'subtitle_location' ); ?>"><?php esc_html_e( 'Subtitle location', self::$_domain ); ?>:</label>
 			<select name="<?php echo $widget->get_field_name( 'subtitle_location' ); ?>" id="<?php echo $widget->get_field_id( 'subtitle_location' ); ?>">
 			<?php
+			$locations = $this->get_available_subtitle_locations( $widget, $instance );
 			foreach ( (array) $locations as $location_key => $location_name ) {
 				?>
 				<option value="<?php echo $location_key; ?>" <?php selected( $instance['subtitle_location'], $location_key, true ); ?>>

--- a/widget-subtitles.php
+++ b/widget-subtitles.php
@@ -560,25 +560,33 @@ final class WS_Widget_Subtitles
 	 * Get the available locations for a widget.
 	 *
 	 * @since   1.1.3
-	 * @param   \WP_Widget  $widget
+	 * @since   1.2.0  Optional `$sidebar_id` parameter.
+	 * @param   \WP_Widget  $widget_obj
 	 * @param   array       $instance
+	 * @param   string      $sidebar_id  The sidebar ID where this widget is located.
 	 * @return  array
 	 */
-	public function get_available_subtitle_locations( $widget, $instance ) {
+	public function get_available_subtitle_locations( $widget_obj, $instance, $sidebar_id = '' ) {
+
+		$widget_id = $widget_obj->id;
+		if ( ! $sidebar_id ) {
+			$sidebar_id = $this->get_widget_sidebar_id( $widget_id );
+		}
 
 		/**
 		 * Filter the available locations.
-		 * Do not append new locations keys. These will be overwritten.
-		 * @todo Also get the sidebar info (if available).
 		 *
 		 * @since   1.1.3
-		 * @param   array       $locations  The array of available locations.
-		 * @param   \WP_Widget  $widget     The widget type class.
-		 * @param   array       $instance   The widget instance.
+		 * @since   1.2.0  Allow custom location + add `$widget_id` and `$sidebar_id` parameters.
+		 *
+		 * @param   array       $locations   The array of available locations.
+		 * @param   \WP_Widget  $widget_obj  The widget object.
+		 * @param   array       $instance    The widget instance.
+		 * @param   string      $widget_id   The widget ID (widget name + instance number).
+		 * @param   string      $sidebar_id  The sidebar ID where this widget is located.
 		 * @return  array  $locations  The available locations: key => label.
 		 */
-		$locations = (array) apply_filters( 'widget_subtitles_available_locations', $this->locations, $widget, $instance );
-		return array_intersect_key( $this->locations, $locations );
+		return (array) apply_filters( 'widget_subtitles_available_locations', $this->locations, $widget_obj, $instance, $widget_id, $sidebar_id );
 	}
 
 	/**

--- a/widget-subtitles.php
+++ b/widget-subtitles.php
@@ -517,15 +517,17 @@ final class WS_Widget_Subtitles
 	 * Get the sidebar ID related to a widget ID.
 	 *
 	 * @since   1.1.1
+	 * @since   1.2.0   Make use of `wp_get_sidebars_widgets()`.
 	 * @access  public
 	 * @param   string  $widget_id  The widget identifier.
 	 * @return  string
 	 */
 	public function get_widget_sidebar_id( $widget_id ) {
-		global $_wp_sidebars_widgets;
+		//global $_wp_sidebars_widgets;
+		$sidebars_widgets = wp_get_sidebars_widgets();
 		$sidebar_id = '';
-		if ( is_array( $_wp_sidebars_widgets ) ) {
-			foreach ( $_wp_sidebars_widgets as $key => $widgets ) {
+		if ( is_array( $sidebars_widgets ) ) {
+			foreach ( $sidebars_widgets as $key => $widgets ) {
 				if ( is_array( $widgets ) && in_array( (string) $widget_id, array_map( 'strval', $widgets ), true ) ) {
 					// Found!
 					$sidebar_id = $key;

--- a/widget-subtitles.php
+++ b/widget-subtitles.php
@@ -3,7 +3,7 @@
  * @author  Jory Hogeveen <info@keraweb.nl>
  * @package Widget_Subtitles
  * @since   0.1.0
- * @version 1.1.4.1
+ * @version 1.2.0-dev
  * @licence GPL-2.0+
  * @link    https://github.com/JoryHogeveen/widget-subtitles
  *
@@ -11,7 +11,7 @@
  * Plugin Name:       Widget Subtitles
  * Plugin URI:        https://wordpress.org/plugins/widget-subtitles/
  * Description:       Add a customizable subtitle to your widgets
- * Version:           1.1.4.1
+ * Version:           1.2-dev
  * Author:            Jory Hogeveen
  * Author URI:        http://www.keraweb.nl
  * Text Domain:       widget-subtitles
@@ -50,7 +50,7 @@ if ( ! class_exists( 'WS_Widget_Subtitles' ) ) {
  * @author  Jory Hogeveen <info@keraweb.nl>
  * @package Widget_Subtitles
  * @since   0.1.0
- * @version 1.1.4.1
+ * @version 1.2.0
  */
 final class WS_Widget_Subtitles
 {
@@ -413,8 +413,8 @@ final class WS_Widget_Subtitles
 			 * @param  string      $widget_id         The widget ID (widget name + instance number).
 			 * @param  string      $sidebar_id        The sidebar ID where this widget is located.
 			 * @param  array       $widget            All widget data.
-			 * @param  \WP_Widget  $widget_obj  The Widget object.
-			 * @return array   An array of CSS classes.
+			 * @param  \WP_Widget  $widget_obj        The Widget object.
+			 * @return array  An array of CSS classes.
 			 */
 			$subtitle_classes = apply_filters( 'widget_subtitles_classes', $subtitle_classes, $widget_id, $sidebar_id, $widget, $widget_obj );
 

--- a/widget-subtitles.php
+++ b/widget-subtitles.php
@@ -542,7 +542,7 @@ final class WS_Widget_Subtitles
 	 */
 	public function get_subtitle_classes( $location ) {
 		// Create subtitle classes.
-		$subtitle_classes = array( 'widget-subtitle', 'widgetsubtitle' );
+		$subtitle_classes = array( 'widgetsubtitle', 'widget-subtitle' );
 		// Add subtitle location classes.
 		$subtitle_classes[] = 'subtitle-' . $location;
 		$location_classes = explode( '-', $location );

--- a/widget-subtitles.php
+++ b/widget-subtitles.php
@@ -423,7 +423,19 @@ final class WS_Widget_Subtitles
 
 			// Start the output.
 			$subtitle = '<' . $subtitle_element . ' class="' . $subtitle_classes . '">';
-			$subtitle .= $instance['subtitle'];
+			/**
+			 * Allow filter to change a widget subtitle.
+			 *
+			 * @since  1.2.0
+			 *
+			 * @param  string      $subtitle    The subtitle.
+			 * @param  string      $widget_id   The widget ID (widget name + instance number).
+			 * @param  string      $sidebar_id  The sidebar ID where this widget is located.
+			 * @param  array       $widget      All widget data.
+			 * @param  \WP_Widget  $widget_obj  The Widget object.
+			 * @return string  The new subtitle.
+			 */
+			$subtitle .= apply_filters( 'widget_subtitle', $instance['subtitle'], $widget_id, $sidebar_id, $widget, $widget_obj );
 			$subtitle .= '</' . $subtitle_element . '>';
 
 			// Add the subtitle.

--- a/widget-subtitles.php
+++ b/widget-subtitles.php
@@ -271,7 +271,7 @@ final class WS_Widget_Subtitles
 				if ( ! $subtitle.val() ) {
 					$subtitle_location.parent().hide();
 				}
-				$(document).on( 'keyup', subtitle, function() {
+				$subtitle.on( 'keyup', function() {
 					if ( $(this).val() ) {
 						$subtitle_location.parent().slideDown('fast');
 					} else {

--- a/widget-subtitles.php
+++ b/widget-subtitles.php
@@ -680,7 +680,7 @@ final class WS_Widget_Subtitles
 				'title' => __( 'Donate', self::$_domain ),
 				'description' => __( 'Buy me a coffee!', self::$_domain ),
 				'icon'  => 'dashicons-smiley',
-				'url'   => 'https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=YGPLMLU7XQ9E8&lc=NL&item_name=Widget%20Subtitles&item_number=JWPP%2dWS&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHostedGuest',
+				'url'   => 'https://www.keraweb.nl/donate.php?for=widget-subtitles',
 			),
 			'plugins' => array(
 				'title' => __( 'Plugins', self::$_domain ),

--- a/widget-subtitles.php
+++ b/widget-subtitles.php
@@ -322,8 +322,8 @@ final class WS_Widget_Subtitles
 		if ( ! empty( $new_instance['subtitle'] ) ) {
 			$instance['subtitle'] = esc_html( strip_tags( $new_instance['subtitle'] ) );
 
-			if ( ! empty( $new_instance['subtitle_location'] ) && array_key_exists( $new_instance['subtitle_location'], $this->locations ) ) {
-				$instance['subtitle_location'] = strip_tags( $new_instance['subtitle_location'] );
+			if ( ! empty( $new_instance['subtitle_location'] ) ) { //&& array_key_exists( $new_instance['subtitle_location'], $this->locations )
+				$instance['subtitle_location'] = esc_attr( strip_tags( $new_instance['subtitle_location'] ) );
 			}
 		}
 

--- a/widget-subtitles.php
+++ b/widget-subtitles.php
@@ -450,13 +450,16 @@ final class WS_Widget_Subtitles
 	 * Add a subtitle in the widget parameters.
 	 *
 	 * @since   1.1.2
+	 * @since   1.2.0  Added optional `$widget_obj` and `$sidebar_id` parameters.
 	 * @access  public
-	 * @param   array   $params             Widget parameters.
-	 * @param   string  $subtitle           The subtitle, may contain HTML.
-	 * @param   string  $subtitle_location  The subtitle location.
+	 * @param   array       $params             Widget parameters.
+	 * @param   string      $subtitle           The subtitle, may contain HTML.
+	 * @param   string      $subtitle_location  The subtitle location.
+	 * @param   \WP_Widget  $widget_obj         The Widget object.
+	 * @param   string      $sidebar_id         The sidebar ID where this widget is located.
 	 * @return  array
 	 */
-	public function add_subtitle( $params, $subtitle, $subtitle_location = '' ) {
+	public function add_subtitle( $params, $subtitle, $subtitle_location = '', $widget_obj = null, $sidebar_id = '' ) {
 
 		if ( empty( $subtitle_location ) ) {
 			$subtitle_location = $this->default_location;
@@ -488,6 +491,22 @@ final class WS_Widget_Subtitles
 
 			case 'after-outside':
 				$params['after_title'] = $params['after_title'] . $subtitle;
+				break;
+
+			default:
+				/**
+				 * Add subtitle at a custom location
+				 *
+				 * @since  0.2.0
+				 *
+				 * @param  array       $params             Widget parameters.
+				 * @param  string      $subtitle           The subtitle.
+				 * @param  string      $subtitle_location  The selected subtitle location.
+				 * @param  \WP_Widget  $widget_obj         The widget object.
+				 * @param  string      $sidebar_id         The sidebar ID where this widget is located.
+				 * @return array
+				 */
+				$params = apply_filters( 'widget_subtitles_add_subtitle', $params, $subtitle, $subtitle_location, $widget_obj, $sidebar_id );
 				break;
 		}
 

--- a/widget-subtitles.php
+++ b/widget-subtitles.php
@@ -582,16 +582,17 @@ final class WS_Widget_Subtitles
 
 		/**
 		 * Filter the available locations.
+		 * Note: Location keys must be strings!
 		 *
 		 * @since   1.1.3
 		 * @since   1.2.0  Allow custom location + add `$widget_id` and `$sidebar_id` parameters.
 		 *
-		 * @param   array       $locations   The array of available locations.
+		 * @param   string[]    $locations   The array of available locations.
 		 * @param   \WP_Widget  $widget_obj  The widget object.
 		 * @param   array       $instance    The widget instance.
 		 * @param   string      $widget_id   The widget ID (widget name + instance number).
 		 * @param   string      $sidebar_id  The sidebar ID where this widget is located.
-		 * @return  array  $locations  The available locations: key => label.
+		 * @return  string[]  $locations  The available locations: key => label.
 		 */
 		return (array) apply_filters( 'widget_subtitles_available_locations', $this->locations, $widget_obj, $instance, $widget_id, $sidebar_id );
 	}

--- a/widget-subtitles.php
+++ b/widget-subtitles.php
@@ -194,9 +194,9 @@ final class WS_Widget_Subtitles
 		);
 
 		add_action( 'init', array( $this, 'load_plugin_textdomain' ) );
-		add_action( 'in_widget_form', array( $this, 'in_widget_form' ), 9, 3 );
-		add_filter( 'widget_update_callback', array( $this, 'widget_update_callback' ), 10, 4 );
-		add_filter( 'dynamic_sidebar_params', array( $this, 'dynamic_sidebar_params' ) );
+		add_action( 'in_widget_form', array( $this, 'action_in_widget_form' ), 9, 3 );
+		add_filter( 'widget_update_callback', array( $this, 'filter_widget_update_callback' ), 10, 4 );
+		add_filter( 'dynamic_sidebar_params', array( $this, 'filter_dynamic_sidebar_params' ) );
 
 		// Add links to plugins page.
 		add_action( 'plugin_row_meta', array( $this, 'action_plugin_row_meta' ), 10, 2 );
@@ -215,6 +215,7 @@ final class WS_Widget_Subtitles
 	 * Add a subtitle input field into the form.
 	 *
 	 * @since   0.1.0
+	 * @since   0.2.0  Add `action_` prefix.
 	 * @access  public
 	 *
 	 * @param   \WP_Widget  $widget
@@ -222,7 +223,7 @@ final class WS_Widget_Subtitles
 	 * @param   array       $instance
 	 * @return  null
 	 */
-	public function in_widget_form( $widget, $return, $instance ) {
+	public function action_in_widget_form( $widget, $return, $instance ) {
 
 		$instance = wp_parse_args(
 			(array) $instance,
@@ -307,6 +308,7 @@ final class WS_Widget_Subtitles
 	 * Filter the widget’s settings before saving, return false to cancel saving (keep the old settings if updating).
 	 *
 	 * @since   0.1.0
+	 * @since   0.2.0  Add `filter_` prefix.
 	 * @access  public
 	 *
 	 * @param   array       $instance
@@ -315,7 +317,7 @@ final class WS_Widget_Subtitles
 	 * param   \WP_Widget  $widget
 	 * @return  array
 	 */
-	public function widget_update_callback( $instance, $new_instance ) {
+	public function filter_widget_update_callback( $instance, $new_instance ) {
 		unset( $instance['subtitle'] );
 		unset( $instance['subtitle_location'] );
 
@@ -339,13 +341,14 @@ final class WS_Widget_Subtitles
 	 * @SuppressWarnings(PHPMD.LongVariables)
 	 *
 	 * @since   0.1.0
+	 * @since   0.2.0  Add `filter_` prefix.
 	 * @access  public
 	 *
 	 * @global  $wp_registered_widgets
 	 * @param   array  $params
 	 * @return  array
 	 */
-	public function dynamic_sidebar_params( $params ) {
+	public function filter_dynamic_sidebar_params( $params ) {
 		global $wp_registered_widgets;
 
 		if ( ! isset( $params[0]['widget_id'] ) ) {

--- a/widget-subtitles.php
+++ b/widget-subtitles.php
@@ -322,7 +322,8 @@ final class WS_Widget_Subtitles
 		if ( ! empty( $new_instance['subtitle'] ) ) {
 			$instance['subtitle'] = esc_html( strip_tags( $new_instance['subtitle'] ) );
 
-			if ( ! empty( $new_instance['subtitle_location'] ) ) { //&& array_key_exists( $new_instance['subtitle_location'], $this->locations )
+			if ( ! empty( $new_instance['subtitle_location'] ) && is_string( $new_instance['subtitle_location'] ) ) {
+				//&& array_key_exists( $new_instance['subtitle_location'], $this->locations )
 				$instance['subtitle_location'] = esc_attr( strip_tags( $new_instance['subtitle_location'] ) );
 			}
 		}

--- a/widget-subtitles.php
+++ b/widget-subtitles.php
@@ -378,7 +378,7 @@ final class WS_Widget_Subtitles
 
 			// default.
 			$subtitle_location = $this->default_location;
-			$locations = $this->get_available_subtitle_locations( $widget_obj, $instance );
+			$locations = $this->get_available_subtitle_locations( $widget_obj, $instance, $sidebar_id );
 
 			// Get location value if it exists and is valid.
 			if ( ! empty( $instance['subtitle_location'] ) && array_key_exists( $instance['subtitle_location'], $locations ) ) {
@@ -439,7 +439,7 @@ final class WS_Widget_Subtitles
 			$subtitle .= '</' . $subtitle_element . '>';
 
 			// Add the subtitle.
-			$params[0] = $this->add_subtitle( $params[0], $subtitle, $subtitle_location );
+			$params[0] = $this->add_subtitle( $params[0], $subtitle, $subtitle_location, $widget, $sidebar_id );
 
 		} // End if().
 

--- a/widget-subtitles.php
+++ b/widget-subtitles.php
@@ -166,16 +166,12 @@ final class WS_Widget_Subtitles
 		 * @param   string  $subtitle_location  The subtitle location (default: 'after-inside').
 		 * @return  string  Options: 'after-inside', 'after-outside', 'before-inside', 'before-outside'.
 		 */
-		$default = apply_filters( 'widget_subtitles_default_location', $this->default_location );
-		$default = explode( '-', $default );
+		$this->default_location = apply_filters( 'widget_subtitles_default_location', $this->default_location );
+		$default = explode( '-', $this->default_location );
 
 		foreach ( $default as $key => $value ) {
 			if ( isset( $loc[ $value ] ) && 2 === count( $default ) ) {
 				$default[ $key ] = $loc[ $value ];
-				continue;
-			} else {
-				$default = array( $loc['after'], $loc['inside'] );
-				break;
 			}
 		}
 

--- a/widget-subtitles.php
+++ b/widget-subtitles.php
@@ -428,18 +428,19 @@ final class WS_Widget_Subtitles
 			// Start the output.
 			$subtitle = '<' . $subtitle_element . ' class="' . $subtitle_classes . '">';
 			/**
-			 * Allow filter to change a widget subtitle.
+			 * Filters the widget subtitle.
 			 *
 			 * @since  1.2.0
 			 *
-			 * @param  string      $subtitle    The subtitle.
+			 * @param  string      $subtitle    The widget subtitle.
+			 * @param  array       $instance    Array of settings for the current widget.
 			 * @param  string      $widget_id   The widget ID (widget name + instance number).
 			 * @param  string      $sidebar_id  The sidebar ID where this widget is located.
 			 * @param  array       $widget      All widget data.
 			 * @param  \WP_Widget  $widget_obj  The Widget object.
 			 * @return string  The new subtitle.
 			 */
-			$subtitle .= apply_filters( 'widget_subtitle', $instance['subtitle'], $widget_id, $sidebar_id, $widget, $widget_obj );
+			$subtitle .= apply_filters( 'widget_subtitle', $instance['subtitle'], $instance, $widget_id, $sidebar_id, $widget, $widget_obj );
 			$subtitle .= '</' . $subtitle_element . '>';
 
 			// Add the subtitle.
@@ -501,9 +502,9 @@ final class WS_Widget_Subtitles
 				/**
 				 * Add subtitle at a custom location
 				 *
-				 * @since  0.2.0
+				 * @since  1.2.0
 				 *
-				 * @param  array       $params             Widget parameters.
+				 * @param  array       $params             Widget sidebar parameters from `dynamic_sidebar_params` filter.
 				 * @param  string      $subtitle           The subtitle.
 				 * @param  string      $subtitle_location  The selected subtitle location.
 				 * @param  \WP_Widget  $widget_obj         The widget object.

--- a/widget-subtitles.php
+++ b/widget-subtitles.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Widget Subtitles
  * Plugin URI:        https://wordpress.org/plugins/widget-subtitles/
  * Description:       Add a customizable subtitle to your widgets
- * Version:           1.2-dev
+ * Version:           1.2-rc1
  * Author:            Jory Hogeveen
  * Author URI:        http://www.keraweb.nl
  * Text Domain:       widget-subtitles


### PR DESCRIPTION
**Changelog**
- [x] **Feature:** New filter: `widget_subtitle` to change the subtitle for a widget. Similar to WP's `widget_title`.
- [x] **Feature:** New filter: `widget_subtitles_add_subtitle` to allow custom subtitle location handlers.
- [x] **Enhancement:** Extended filter: `widget_subtitles_available_locations` now allows custom locations.
- [x] **Enhancement:** Make use of `wp_get_sidebars_widgets()` instead of a global to get the related sidebar ID from a widget instance.
- [x] **Documentation:** Created a wiki on GitHub.

**TODO**
- [x] Create wiki (too many filters for the plugin description)
  - [x] Add new filters to documentation
- [x] Update readme with links to wiki
- [x] Unit tests